### PR TITLE
refactored API endpoints migrating from body to params based queries

### DIFF
--- a/server/controller/tastyAPI/tastyApiController.js
+++ b/server/controller/tastyAPI/tastyApiController.js
@@ -111,7 +111,7 @@ tastyApiController.tastyList = (req, res, next) => {
                     title: el.name,
                     description: `${(el.total_time_tier !== undefined) ? el.total_time_tier : ''} - ${el.description}`,
                     directions: preparations,
-                    ingredients,
+                    ingredientList: ingredients,
                     tags: recipeTags,
                     imageUrl: el.thumbnail_url
                 })                

--- a/server/controller/tastyAPI/tastyApiController.js
+++ b/server/controller/tastyAPI/tastyApiController.js
@@ -14,7 +14,7 @@ const options = {
 }
 
 tastyApiController.tastyAutoCompleteQuery = (req, res, next) => {
-    const query = req.body.query;
+    const query = req.params.searchTerm;
     const type = tastyTypes.recipes.AUTO_COMPLETE;
 
     fetch(`${url}recipes/${type}?prefix=${query}`, options)
@@ -37,29 +37,36 @@ tastyApiController.tastyAutoCompleteQuery = (req, res, next) => {
 }
 
 tastyApiController.tastyList = (req, res, next) => {
-    const start = req.body.start;
-    const size = req.body.size;
-    const tags = req.body.tags;
-    const q = req.body.q;
+    const start = req.params.start;
+    const size = req.params.size;
+    let tags = req.params.tags;
+    let q = req.params.q;
     const type = tastyTypes.recipes.LIST;
-
-    for (let i = 0; i < tags.length; i++) {
-        if (i === 0) continue;
-        else {
-            tags[i] = `%20${tags[i]}`
+    if (tags !== 'null') {
+        tags = tags.split(' ');
+        for (let i = 0; i < tags.length; i++) {
+            if (i === 0) continue;
+            else {
+                tags[i] = `%20${tags[i]}`
+            }
         }
+        tags.join(',');
+    } else {
+        tags = '';
     }
 
-    tags.join(',');
-
-    for (let i = 0; i < q.length; i++) {
-        if (i === 0) continue;
-        else {
-            q[i] = `%20${q[i]}`
+    if (q !== 'null') {
+        q = q.split(' ');
+        for (let i = 0; i < q.length; i++) {
+            if (i === 0) continue;
+            else {
+                q[i] = `%20${q[i]}`
+            }
         }
+        q.join(',');
+    } else {
+        q = '';
     }
-
-    q.join(',');
 
     fetch(`${url}recipes/${type}?from=${start}&size=${size}${tags.length > 0 ? `&tags=${tags}`: ''}${q.length > 0 ? `&q=${q}`: ''}`, options)
         .then(result => result.json())
@@ -154,7 +161,7 @@ tastyApiController.tastyGetTags = (req, res, next) => {
 // TODO: implement finding similar recipe as an extension
 
 tastyApiController.tastyFindSimilarRecipeByID = (req, res, next) => {
-    const id = req.body.id;
+    const id = req.params.id;
     const type = tastyTypes.recipes.LIST_SIMILARITIES;
 
     fetch(`${url}recipes/${type}?recipe_id=${id}`, options)

--- a/server/routes/tastyRoute.js
+++ b/server/routes/tastyRoute.js
@@ -1,15 +1,17 @@
 const router = require('express').Router();
 const tastyController = require('../controller/tastyAPI/tastyApiController');
 
-router.get('/search', tastyController.tastyAutoCompleteQuery, (req, res, next) => {
+router.get('/search/:searchTerm', tastyController.tastyAutoCompleteQuery, (req, res, next) => {
     res.status(200).send(res.locals.queryData);
   });
 
-router.get('/tagQuery', tastyController.tastyList, (req, res, next) => {
+//   http://localhost:3000/tasty/tagQuery/?from=0&size=50&tags=[]&q=${keywords}'
+
+router.get('/tagQuery/:start/:size/:tags/:q', tastyController.tastyList, (req, res, next) => {
     res.status(200).send(res.locals.tastyList);
 });
 
-router.get('/findSimilarRecipe', tastyController.tastyFindSimilarRecipeByID, (req, res, next) => {
+router.get('/findSimilarRecipe/:id', tastyController.tastyFindSimilarRecipeByID, (req, res, next) => {
     res.status(200).send(res.locals.similarRecipe);
 });
 


### PR DESCRIPTION
## Overview
- refactored API endpoints migrating from the body to params-based queries

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
- The endpoint would look like this /tagQuery/:start/:size/:tags/:q
- In practice you would send something back like this: http://localhost:3000/tasty/tagQuery/0/50/null/hot%20dog
- In this example hot dog needs to be spaced out in order for the query to Tasty to work, therefore, any request that is typed out as a space like pesto pasta to be send on the q param as pesto%20pasta
- The null text needs to be placed on the tag params or the q params if the user does not select any options for these respective parameters
- if there are multiple tags the url would like this http://localhost:3000/tasty/tagQuery/0/50/italian%20under_30_minutes/pesto%20pasta
![image](https://user-images.githubusercontent.com/105384182/232145997-bafd3195-2f1c-4c15-81ce-d7d29133363f.png)